### PR TITLE
Update redis source timestamp from seconds to milliseconds

### DIFF
--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverter.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverter.java
@@ -55,7 +55,7 @@ public class RecordConverter {
       key,
       VALUE_SCHEMA,
       value,
-      Instant.now().getEpochSecond()
+      Instant.now().toEpochMilli()
     );
   }
 }

--- a/src/test/unit/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverterTest.java
+++ b/src/test/unit/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverterTest.java
@@ -23,6 +23,9 @@ class RecordConverterTest {
     final RecordConverter recordConverter = new RecordConverter(topic);
     final SourceRecord sourceRecord = recordConverter.convert(redisMessage);
 
+    System.out.println(sourceRecord.timestamp());
+    System.out.println(Instant.now().toEpochMilli());
+
     assertTrue(sourceRecord.sourcePartition().isEmpty());
     assertTrue(sourceRecord.sourceOffset().isEmpty());
     assertEquals(topic, sourceRecord.topic());
@@ -32,6 +35,6 @@ class RecordConverterTest {
     assertEquals(redisMessage.getPattern(), ((Struct) sourceRecord.key()).getString("pattern"));
     assertEquals(Schema.Type.STRUCT, sourceRecord.valueSchema().type());
     assertEquals(redisMessage.getMessage(), ((Struct) sourceRecord.value()).getString("message"));
-    assertTrue(sourceRecord.timestamp() <= Instant.now().getEpochSecond());
+    assertTrue(sourceRecord.timestamp() <= Instant.now().toEpochMilli());
   }
 }

--- a/src/test/unit/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverterTest.java
+++ b/src/test/unit/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverterTest.java
@@ -23,9 +23,6 @@ class RecordConverterTest {
     final RecordConverter recordConverter = new RecordConverter(topic);
     final SourceRecord sourceRecord = recordConverter.convert(redisMessage);
 
-    System.out.println(sourceRecord.timestamp());
-    System.out.println(Instant.now().toEpochMilli());
-
     assertTrue(sourceRecord.sourcePartition().isEmpty());
     assertTrue(sourceRecord.sourceOffset().isEmpty());
     assertEquals(topic, sourceRecord.topic());


### PR DESCRIPTION
updated SourceRecord timestamp parameter from seconds to milliseconds.

The redis connector was adding timestamp in seconds instead of milliseconds, this created event timestamp in 1970 year. The record gets removed by the Kafka because of retention policy of few days.

